### PR TITLE
Wrap blocking IO in BEGIN_THREADS/END_THREADS

### DIFF
--- a/alsaseq.c
+++ b/alsaseq.c
@@ -313,7 +313,10 @@ alsaseq_input(PyObject *self, PyObject *args)
         
 	if (!PyArg_ParseTuple(args, "" ))
 		return NULL;
+
+        Py_BEGIN_ALLOW_THREADS
         snd_seq_event_input( seq_handle, &ev );
+        Py_END_ALLOW_THREADS
 
         switch( ev->type ) {
         case SND_SEQ_EVENT_NOTE:


### PR DESCRIPTION
Hi, I'm using alsaseq in my project [MFP](https://github.com/bgribble/mfp).  Thanks for your work!

To use alsaseq in a multithreaded environment you need to wrap the blocking IO in this pair of macros; see the [Python 3 docs](https://docs.python.org/3/c-api/init.html).

This approach is compatible with Python 2.x and 3.x; my project uses Python 2.x.

I have been using this patch on my local tree for quite some time and it works :)