### PR TITLE
Additional commands to allow connection/disconnection of 2 third-party apps

### DIFF
--- a/alsaseq.c
+++ b/alsaseq.c
@@ -472,6 +472,21 @@ alsaseq_connect(PyObject *self, PyObject *args)
         return PyInt_FromLong(res);
 }
 
+static void loop_over_all_ports(void (*func)(snd_seq_client_info_t*, snd_seq_port_info_t*, void*), void* data){
+        snd_seq_client_info_t *cinfo;
+        snd_seq_port_info_t *pinfo;
+
+        snd_seq_client_info_alloca(&cinfo);
+        snd_seq_port_info_alloca(&pinfo);
+        snd_seq_client_info_set_client(cinfo, -1);
+        while (snd_seq_query_next_client(seq_handle, cinfo) >= 0) {
+                snd_seq_port_info_set_client(pinfo, snd_seq_client_info_get_client(cinfo));
+                snd_seq_port_info_set_port(pinfo, -1);
+                while (snd_seq_query_next_port(seq_handle, pinfo) >= 0) {
+                        func(cinfo, pinfo, data);
+                }
+        }
+}
 
 static char alsaseq_listconnections__doc__[] =
 "listconnections() --> list of connections.\n\nList alsa midi connections."
@@ -480,8 +495,6 @@ static char alsaseq_listconnections__doc__[] =
 static PyObject *
 alsaseq_listconnections(PyObject *self, PyObject *args)
 {
-        PyObject* list = PyList_New(0);
-
 	if (!PyArg_ParseTuple(args, ""))
 		return NULL;
 
@@ -490,16 +503,10 @@ alsaseq_listconnections(PyObject *self, PyObject *args)
                 return NULL;
         }
 
-        snd_seq_client_info_t *cinfo;
-        snd_seq_port_info_t *pinfo;
+        PyObject* list = PyList_New(0);
 
-        snd_seq_client_info_alloca(&cinfo);
-        snd_seq_port_info_alloca(&pinfo);
-        snd_seq_client_info_set_client(cinfo, -1);
-        while (snd_seq_query_next_client(seq_handle, cinfo) >= 0) {
-            snd_seq_port_info_set_client(pinfo, snd_seq_client_info_get_client(cinfo));
-            snd_seq_port_info_set_port(pinfo, -1);
-            while (snd_seq_query_next_port(seq_handle, pinfo) >= 0) {
+        void port_connections_to(snd_seq_client_info_t* cinfo, snd_seq_port_info_t* pinfo, void* data){
+                PyObject* list = (PyObject*)data;
                 const snd_seq_addr_t* addr = snd_seq_port_info_get_addr(pinfo);
 
                 snd_seq_query_subscribe_t *subs;
@@ -509,25 +516,26 @@ alsaseq_listconnections(PyObject *self, PyObject *args)
                 snd_seq_query_subscribe_set_type(subs, SND_SEQ_QUERY_SUBS_READ); // connecting to
                 snd_seq_query_subscribe_set_index(subs, 0);
                 while (snd_seq_query_port_subscribers(seq_handle, subs) >= 0) {
-                    const snd_seq_addr_t *conn_addr = snd_seq_query_subscribe_get_addr(subs);
-                    PyObject* root_tuple = PyTuple_New(2);
-                    PyObject* from_tuple = PyTuple_New(2);
-                    PyObject* to_tuple   = PyTuple_New(2);
+                        const snd_seq_addr_t *conn_addr = snd_seq_query_subscribe_get_addr(subs);
+                        PyObject* root_tuple = PyTuple_New(2);
+                        PyObject* from_tuple = PyTuple_New(2);
+                        PyObject* to_tuple   = PyTuple_New(2);
 
-                    PyTuple_SetItem(from_tuple, 0, PyInt_FromLong(addr->client));
-                    PyTuple_SetItem(from_tuple, 1, PyInt_FromLong(addr->port));
+                        PyTuple_SetItem(from_tuple, 0, PyInt_FromLong(addr->client));
+                        PyTuple_SetItem(from_tuple, 1, PyInt_FromLong(addr->port));
 
-                    PyTuple_SetItem(to_tuple, 0, PyInt_FromLong(conn_addr->client));
-                    PyTuple_SetItem(to_tuple, 1, PyInt_FromLong(conn_addr->port));
+                        PyTuple_SetItem(to_tuple, 0, PyInt_FromLong(conn_addr->client));
+                        PyTuple_SetItem(to_tuple, 1, PyInt_FromLong(conn_addr->port));
 
-                    PyTuple_SetItem(root_tuple, 0, from_tuple);
-                    PyTuple_SetItem(root_tuple, 1, to_tuple);
+                        PyTuple_SetItem(root_tuple, 0, from_tuple);
+                        PyTuple_SetItem(root_tuple, 1, to_tuple);
 
-                    PyList_Append(list, root_tuple);
-                    snd_seq_query_subscribe_set_index(subs, snd_seq_query_subscribe_get_index(subs) + 1);
+                        PyList_Append(list, root_tuple);
+                        snd_seq_query_subscribe_set_index(subs, snd_seq_query_subscribe_get_index(subs) + 1);
                 }
-            }
         }
+
+        loop_over_all_ports(port_connections_to, (void*)list);
 
         return list;
 }

--- a/alsaseq.c
+++ b/alsaseq.c
@@ -504,6 +504,41 @@ alsaseq_connect(PyObject *self, PyObject *args)
         return PyInt_FromLong(res);
 }
 
+static char alsaseq_disconnect__doc__[] =
+"disconnect(in_client, in_port, out_client, out_port) --> alsa error code.\n\nDisconnect two client:ports if they are already connected."
+;
+
+static PyObject *
+alsaseq_disconnect(PyObject *self, PyObject *args)
+{
+        int in_client, in_port, out_client, out_port;
+        snd_seq_port_subscribe_t* subs;
+        snd_seq_addr_t sender, dest;
+
+	if (!PyArg_ParseTuple(args, "iiii", &in_client, &in_port, &out_client, &out_port ))
+		return NULL;
+
+        if (!seq_handle) {
+                PyErr_SetString(PyExc_RuntimeError, "Must initialize module with alsaseq.client() before using it");
+                return NULL;
+        }
+
+        snd_seq_port_subscribe_malloc(&subs);
+        memset(subs, 0, snd_seq_port_subscribe_sizeof());
+        sender.client = in_client;
+        sender.port = in_port;
+        dest.client = out_client;
+        dest.port = out_port;
+        snd_seq_port_subscribe_set_sender(subs, &sender);
+        snd_seq_port_subscribe_set_dest(subs, &dest);
+
+        int res = snd_seq_unsubscribe_port(seq_handle, subs);
+
+        snd_seq_port_subscribe_free(subs);
+        return PyInt_FromLong(res);
+}
+
+
 static char alsaseq_listconnections__doc__[] =
 "listconnections() --> list of connections.\n\nList alsa midi connections."
 ;
@@ -628,6 +663,7 @@ static struct PyMethodDef alsaseq_methods[] = {
  {"input",	(PyCFunction)alsaseq_input,	METH_VARARGS,	alsaseq_input__doc__},
  {"fd",	(PyCFunction)alsaseq_fd,	METH_VARARGS,	alsaseq_fd__doc__},
  {"connect", (PyCFunction)alsaseq_connect, METH_VARARGS, alsaseq_connect__doc__},
+ {"disconnect", (PyCFunction)alsaseq_disconnect, METH_VARARGS, alsaseq_disconnect__doc__},
  {"listconnections", (PyCFunction)alsaseq_listconnections, METH_VARARGS, alsaseq_listconnections__doc__},
  {"listdevices", (PyCFunction)alsaseq_listdevices, METH_VARARGS, alsaseq_listdevices__doc__},
  

--- a/alsaseq.c
+++ b/alsaseq.c
@@ -438,6 +438,40 @@ alsaseq_fd(PyObject *self, PyObject *args)
 }
 
 
+static char alsaseq_connect__doc__[] =
+"connect(in_client, in_port, out_client, out_port) --> alsa error code.\n\nConnect two client:ports."
+;
+
+static PyObject *
+alsaseq_connect(PyObject *self, PyObject *args)
+{
+        int in_client, in_port, out_client, out_port;
+        snd_seq_port_subscribe_t* subs;
+        snd_seq_addr_t sender, dest;
+
+	if (!PyArg_ParseTuple(args, "iiii", &in_client, &in_port, &out_client, &out_port ))
+		return NULL;
+
+        if (!seq_handle) {
+                PyErr_SetString(PyExc_RuntimeError, "Must initialize module with alsaseq.client() before using it");
+                return NULL;
+        }
+
+        snd_seq_port_subscribe_malloc(&subs);
+        memset(subs, 0, snd_seq_port_subscribe_sizeof());
+        sender.client = in_client;
+        sender.port = in_port;
+        dest.client = out_client;
+        dest.port = out_port;
+        snd_seq_port_subscribe_set_sender(subs, &sender);
+        snd_seq_port_subscribe_set_dest(subs, &dest);
+
+        int res = snd_seq_subscribe_port(seq_handle, subs);
+
+        snd_seq_port_subscribe_free(subs);
+        return PyInt_FromLong(res);
+}
+
 /* start python 2 & python 3 dual support for initialization */
 
 struct module_state {
@@ -466,6 +500,7 @@ static struct PyMethodDef alsaseq_methods[] = {
  {"id",	(PyCFunction)alsaseq_id,	METH_VARARGS,	alsaseq_id__doc__},
  {"input",	(PyCFunction)alsaseq_input,	METH_VARARGS,	alsaseq_input__doc__},
  {"fd",	(PyCFunction)alsaseq_fd,	METH_VARARGS,	alsaseq_fd__doc__},
+ {"connect", (PyCFunction)alsaseq_connect, METH_VARARGS, alsaseq_connect__doc__},
  
 	{NULL,	 (PyCFunction)NULL, 0, NULL}		/* sentinel */
 };


### PR DESCRIPTION
This code was original written by @zelenikotao, but there wasn't a pull request and he doesn't seem active on GitHub for a while.

These will allow a script to control the connections of third party ALSA apps. Connections remain after the script has terminated, and are also viewable/controllable via system tools (such as 'aconnect').

For example, breaking the connection between Keyboard and soft-synth to insert itself in the path. Once the script is done it could re-establish the (direct) connection.
